### PR TITLE
Separation of extinction into its thermal and scattering components

### DIFF
--- a/src/background.jl
+++ b/src/background.jl
@@ -85,13 +85,14 @@ function α_cont(
     temperature::T,
     electron_density::T,
     hydrogen_density::T,
-)::T where T <: AbstractFloat
+)::Tuple{T,T} where T <: AbstractFloat
     log_temp = log10(temperature)
     log_ne = log10(electron_density)
-    α = itp.σ_H(log_temp, log_ne) * hydrogen_density
-    α += (itp.σ_H2(log_temp, log_ne) * hydrogen_density) * hydrogen_density
-    α += σ_THOMSON * electron_density
-    return α
+    α_thermal = itp.σ_H(log_temp, log_ne) * hydrogen_density
+    α_thermal += (itp.σ_H2(log_temp, log_ne) * hydrogen_density) * hydrogen_density
+
+    α_scattering = σ_THOMSON * electron_density
+    return α_thermal, α_scattering
 end
 
 
@@ -130,17 +131,20 @@ function α_cont(
     electron_density::T,
     h_neutral_density::T,
     proton_density::T,
-)::T where T <: AbstractFloat
+)::Tuple{T,T} where T <: AbstractFloat
     log_temp = log10(temperature)
-    log_ne = log10(electron_density)
+    log_ne   = log10(electron_density)
     hydrogen_density = h_neutral_density + proton_density
-    α = itp.σ_atoms(log_temp, log_ne) * hydrogen_density
-    α += (itp.σ_hminus(log_temp) * electron_density) * h_neutral_density
-    α += (itp.σ_h_ff(log_temp) * electron_density) * proton_density
-    α += (itp.σ_h2plus(log_temp) * proton_density) * h_neutral_density
-    α += ustrip(σ_rayleigh_h(itp.λ * u"nm")) * h_neutral_density
-    α += σ_THOMSON * electron_density
-    return α
+
+    α_thermal  = itp.σ_atoms(log_temp, log_ne) * hydrogen_density
+    α_thermal += (itp.σ_hminus(log_temp) * electron_density) * h_neutral_density
+    α_thermal += (itp.σ_h_ff(log_temp) * electron_density) * proton_density
+    α_thermal += (itp.σ_h2plus(log_temp) * proton_density) * h_neutral_density
+
+    α_scattering  = ustrip(σ_rayleigh_h(itp.λ * u"nm")) * h_neutral_density
+    α_scattering += σ_THOMSON * electron_density
+    
+    return α_thermal, α_scattering
 end
 
 
@@ -167,28 +171,30 @@ bound-free processes from background atoms.
 - `proton_density`: Proton number density in m^-3.
 
 # Returns
-- `α`: Continuous extinction (Float) in m^-1.
-"""
+- `α_thermal`: Continuous thermal extinction (Float) in m^-1.
+- `α_scattering`: Continuous scattering extinction (Float) in m^-1."""
 function α_cont_no_itp(
     λ::T,
     temperature::T,
     electron_density::T,
     h_neutral_density::T,
-    proton_density::T
-) where T <: AbstractFloat
+    proton_density::T,
+)::Tuple{T,T} where T <: AbstractFloat
     λ *= u"nm"
     temperature *= u"K"
     electron_density *= u"m^-3"
     h_neutral_density *= u"m^-3"
     proton_density *= u"m^-3"
-    α = α_hminus_ff(λ, temperature, h_neutral_density,  electron_density)
-    α += α_hminus_bf(λ, temperature, h_neutral_density, electron_density)
-    α += α_hydrogenic_ff(c_0 / λ, temperature, electron_density, proton_density, 1)
-    α += α_h2plus_ff(λ, temperature, h_neutral_density, proton_density)
-    α += α_h2plus_bf(λ, temperature, h_neutral_density, proton_density)
-    α += α_thomson(electron_density)
-    α += α_rayleigh_h(λ, h_neutral_density)
-    return ustrip(α |> u"m^-1")
+
+    α_thermal  = α_hminus_ff(λ, temperature, h_neutral_density,  electron_density)
+    α_thermal += α_hminus_bf(λ, temperature, h_neutral_density, electron_density)
+    α_thermal += α_hydrogenic_ff(c_0 / λ, temperature, electron_density, proton_density, 1)
+    α_thermal += α_h2plus_ff(λ, temperature, h_neutral_density, proton_density)
+    α_thermal += α_h2plus_bf(λ, temperature, h_neutral_density, proton_density)
+
+    α_scattering  = α_thomson(electron_density)
+    α_scattering += α_rayleigh_h(λ, h_neutral_density)
+    return ustrip(α_thermal |> u"m^-1"), ustrip(α_scattering |> u"m^-1")
 end
 
 #=----------------------------------------------------------------------------

--- a/src/intensity.jl
+++ b/src/intensity.jl
@@ -165,21 +165,23 @@ function calc_τ_cont!(
     σ_itp::ExtinctionItpNLTE{<:Real},
 ) where T <: AbstractFloat
     τ[1] = zero(T)
-    α = α_cont(
+    α_thermal, α_scattering = α_cont(
         σ_itp,
         atm.temperature[1],
         atm.electron_density[1],
         atm.hydrogen1_density[1],
         atm.proton_density[1]
     )
+    α = α_thermal + α_scattering
     for i in 2:atm.nz
-        α_next = α_cont(
+        α_thermal_next, α_scattering_next = α_cont(
             σ_itp,
             atm.temperature[i],
             atm.electron_density[i],
             atm.hydrogen1_density[i],
             atm.proton_density[i]
         )
+        α_next = α_thermal_next + α_scattering_next
         τ[i] = τ[i-1] + abs(atm.z[i] - atm.z[i-1]) * (α + α_next) / 2
         α = α_next
     end

--- a/src/intensity.jl
+++ b/src/intensity.jl
@@ -12,14 +12,18 @@ function calc_line_prep!(
     σ_itp::ExtinctionItpNLTE{<:Real},
 ) where T <: AbstractFloat
     for i in 1:atm.nz
-        buf.α_c[i] = α_cont(
+        αc_thermal, αc_scattering = α_cont(
             σ_itp,
             atm.temperature[i],
             atm.electron_density[i],
             atm.hydrogen1_density[i],
             atm.proton_density[i]
         )
-        buf.j_c[i] = buf.α_c[i] * blackbody_λ(line.λ0, atm.temperature[i])
+
+        buf.α_c[i] = αc_thermal + αc_scattering
+
+        buf.j_c[i] = αc_thermal * blackbody_λ(line.λ0, atm.temperature[i])
+
         buf.γ[i] = calc_broadening(
             line.γ,
             atm.temperature[i],

--- a/test/background.jl
+++ b/test/background.jl
@@ -42,8 +42,8 @@ import Muspel: create_σ_itp_LTE, create_σ_itp_NLTE, get_atoms_bf_interpolant, 
         itp_test = get_σ_itp(atmos_test, 500., atoms_list; npts=101)
         @test isa(itp_test, ExtinctionItpNLTE{Float64})
         @test isapprox(
-            α_cont(itp_nlte2, 5000., 1e20, 1e20, 1e20),
-            α_cont(itp_test, 5000., 1e20, 1e20, 1e20),
+            stack(α_cont(itp_nlte2, 5000., 1e20, 1e20, 1e20)),
+            stack(α_cont(itp_test, 5000., 1e20, 1e20, 1e20)),
             rtol=1e-3
         )
         @test_throws SystemError get_σ_itp(atmos_test, 500., ["nofile.yaml"])
@@ -56,36 +56,44 @@ import Muspel: create_σ_itp_LTE, create_σ_itp_NLTE, get_atoms_bf_interpolant, 
             nHII = ni .* ion_frac
             # Check if LTE and NLTE give same result, assuming Saha for hydrogen
             @test isapprox(
-                α_cont.(Ref(itp_lte), temp, ni, ni),
-                α_cont.(Ref(itp_nlte), temp, ni, nHI, nHII),
+                stack(α_cont.(Ref(itp_lte), temp, ni, ni)),
+                stack(α_cont.(Ref(itp_nlte), temp, ni, nHI, nHII)),
                 rtol=1e-5,
             )
             # Check if interpolant with no atoms gives same result as α_cont_no_itp
             @test isapprox(
-                α_cont_no_itp.(λ[1], temp, ni, nHI, nHII),
-                α_cont.(Ref(itp_nlte_empty), temp, ni, nHI, nHII),
+                stack(α_cont_no_itp.(λ[1], temp, ni, nHI, nHII)),
+                stack(α_cont.(Ref(itp_nlte_empty), temp, ni, nHI, nHII)),
                 rtol=1e-5,
             )
         end
         # Some checks against implementation
-        prev = [3.166260014050373e-9   1.2390038437211058e-10  2.8355199724497864e-10
-                2.3365757985473882e-8  4.1969276633548743e-10  1.4792957612236907e-9
-                3.19501480342208e-8    5.232736686830469e-10   2.039376943876063e-9
-                1.1834781970475661e-9  2.1924407940343387e-10  5.4690898709933755e-9
-                2.0918382712344928e-10 2.886350125152959e-10   9.258069388938863e-9]
+        prev = [3.099735426728638e-9 5.737579705215677e-11 2.1702740948438375e-10; 
+                2.329923339815215e-8 3.531681790200384e-10 1.4127711713968792e-9; 
+                3.188362344689906e-8 4.5674908136823566e-10 1.9728523541442412e-9; 
+                1.1169536097258309e-9 1.5271949210413109e-10 5.402565280664961e-9; 
+                1.426592398017141e-10 2.2211042523024984e-10 9.191544796655046e-9;;; 
+                6.652458732173518e-11 6.652458732173518e-11 6.652458732173518e-11; 
+                6.652458732173518e-11 6.652458732173518e-11 6.652458732173518e-11; 
+                6.652458732173518e-11 6.652458732173518e-11 6.652458732173518e-11; 
+                6.652458732173518e-11 6.652458732173518e-11 6.652458732173518e-11; 
+                6.652458732173518e-11 6.652458732173518e-11 6.652458732173518e-11]
         for (i, λi) in enumerate(λ)
             itp = create_σ_itp_LTE(λi, log_temp, log_ne, H, atoms, σ_atom_itp)
-            @test α_cont.(Ref(itp), temp, 1e18, 1e20) ≈ prev[i, :]
+            @test permutedims(stack(α_cont.(Ref(itp), temp, 1e18, 1e20))) ≈ prev[i, :, :]
         end
     end
 
     @testset "α_cont_no_itp" begin
         # Against previous implementation:
-        prev = [1.052784352703514, 3.5727512640936836, 4.628599312906391,
-               1.9725067321692635, 2.5417412522755836] * 1e-8
-        @test all(α_cont_no_itp.(λ, 6e3, 1e20, 1e20, 4e15) .≈ prev)
+        prev = [0.3875384794861622     0.6652458732173518
+                2.906477474892972      0.6662737892007118
+                3.9632382586598986     0.6653610542464922
+                1.307251908032521      0.66525482413674265
+                1.876491725439709      0.6652495268358745] * 1e-8
+        @test permutedims(stack(α_cont_no_itp.(λ, 6e3, 1e20, 1e20, 4e15))) ≈ prev
         # Consistency check, Hmin maximum extinction
-        @test argmax(α_cont_no_itp.(λ, 6e3, 1e20, 1.0e20, 4e15)) == 3
+        @test argmax(α_cont_no_itp.(λ, 6e3, 1e20, 1.0e20, 4e15)) == 3 # Only checks thermal scatt
     end
 
     @testset "σH" begin

--- a/test/intensity.jl
+++ b/test/intensity.jl
@@ -48,7 +48,6 @@ using AtomicData
         # Consistency tests
         @test buf.intensity[end] == buf.int_tmp[1]
         S_Planck = blackbody_λ.(my_line.λ0, atm.temperature)
-        @test isapprox(S_Planck, buf.source_function, rtol=1e-2)  # S = B for continuum
         @test isapprox(buf.j_c ./ buf.α_c, buf.source_function, rtol=1e-2)  # S = S_c
         @test all(buf.source_function .> 0)
         @test all(buf.α_c .> 0)
@@ -85,7 +84,6 @@ using AtomicData
         calc_line_1D!(my_line, buf ,my_line.λ, atm, n_u, n_l, voigt_itp;
                       to_end=true, initial_condition=:zero)
         @test buf.intensity[end] == buf.int_tmp[end]
-        @test isapprox(S_Planck, buf.source_function, rtol=1e-2)  # S = B for continuum
 
         # Test isotopes
         iso_fraction = [0.5, 0.5]


### PR DESCRIPTION
Updates the functions for the continuum extinction to return thermal and scattering parts separately. 

Changes: 
- `α_cont` and `α_cont_no_itp` now return Tuple{T,T}: (thermal_extinction, scattering_extinction)
- Call sites updated:
    - total extinction is now α_total = α[1] + α[2]
    - For the emissivity only the thermal part is used. This can be changed to include J in the future. 
- Tests have been updated to match the new return type 